### PR TITLE
Fixes some issues with asserts regarding the kernel_size and padding …

### DIFF
--- a/conv4d.py
+++ b/conv4d.py
@@ -9,7 +9,7 @@ class Conv4d_broadcast(nn.Module):
     def __init__(self, in_channels,
                  out_channels,
                  kernel_size,
-                 padding=None,
+                 padding,
                  stride=1,
                  padding_mode='circular',
                  dilation=1,
@@ -36,13 +36,6 @@ class Conv4d_broadcast(nn.Module):
         # create tuple if argument is just a number
         if not isinstance(kernel_size, tuple):
             kernel_size = tuple(kernel_size for _ in range(Nd))
-        # construct correct padding tuple for given padding_mode
-        if padding is None:
-            if padding_mode == 'circular':
-                padding = tuple(_ks-1 for _ks in kernel_size)
-            else:
-                padding = tuple(0 for _ in kernel_size)
-        # create tuple if argument is just a number
         if not isinstance(padding, tuple):
             padding = tuple(padding for _ in range(Nd))
 
@@ -50,7 +43,7 @@ class Conv4d_broadcast(nn.Module):
             'Non-zero padding currently only supported for circular padding mode.'
         if padding_mode == 'circular':
             assert padding == tuple(_ks - 1 for _ks in kernel_size), \
-                'Padding for circular padding_mode must be kernel_size-1. Use padding=None to ensure this automatically.'
+                f'Padding for circular padding_mode must be kernel_size-1. Have padding = {padding} and kernel_size = {kernel_size}.'
 
         self.conv_f = (nn.Conv2d, nn.Conv3d)[Nd - 3]
         self.out_channels = out_channels

--- a/conv4d.py
+++ b/conv4d.py
@@ -42,8 +42,9 @@ class Conv4d_broadcast(nn.Module):
         assert padding_mode == 'circular' or padding == tuple(0 for _ in padding), \
             'Non-zero padding currently only supported for circular padding mode.'
         if padding_mode == 'circular':
-            assert padding == tuple(_ks - 1 for _ks in kernel_size), \
-                f'Padding for circular padding_mode must be kernel_size-1. Have padding = {padding} and kernel_size = {kernel_size}.'
+            for _pd, _ks in zip(padding, kernel_size):
+                assert _pd == _ks-1 or _pd == 0, \
+                    f'Padding for circular padding_mode must be 0 or kernel_size-1. Have padding = {padding} and kernel_size = {kernel_size}.'
 
         self.conv_f = (nn.Conv2d, nn.Conv3d)[Nd - 3]
         self.out_channels = out_channels


### PR DESCRIPTION
…arguments, and adds code to construct the correct padding from kernel_size automatically for padding_mode = 'circular'. Tests are passing.

1. Some asserts were failing for certain valid arguments due to comparing tuples with ints or lists, now all variables are forced to be tuples once this point is reached.
2. padding_mode = 'zeros' is not the same as padding = 0, this condition has been removed from the assert ensuring that padding != 0 only for padding_mode = 'circular'.
3. For a given kernel_size and padding_mode = 'circular', the appropriate padding must be kernel_size-1. This was checked with an assert already, but now it can also be ensured autoamtically by passing padding = None together with padding_mode = 'circular'.